### PR TITLE
Fixed tarballs generation script

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -29,8 +29,7 @@ ENGINE=$(echo $TAG | sed -r -e 's/BABEL_([0-9_]*)__PG_([0-9]+_)/\2/' -e 's/_/./g
 EXT_STABLE_BRANCH=$(echo $TAG | sed -r -e 's/([0-9a-z_]*)_.__PG.*/\1/' -e 's/$/_STABLE/')
 
 function helper() {
-  sed -r -e 's/\{\{VERSION\}\}/'''$VERSION'''/'  $1
-  sed -r -e 's/\{\{ENGINE\}\}/'''$ENGINE'''/'  $1
+  sed -r -e 's/\{\{VERSION\}\}/'''$VERSION'''/' -e 's/\{\{ENGINE\}\}/'''$ENGINE'''/' $1
 }
 
 rm -rf ${OUTDIR}


### PR DESCRIPTION




*Description*
To generate zip and tar files, release workflow uses already written bash script. The script was appending the installation template two times. This commit fix the script so that it work properly. 

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
