### PR TITLE
Update GitHub Actions to use v4 of actions/upload-artifact or actions…

### DIFF
--- a/.github/workflows/install-and-verify.yml
+++ b/.github/workflows/install-and-verify.yml
@@ -18,10 +18,10 @@ jobs:
     env:
       JOBS: 4 # Adjust to number of cores
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         id: checkout
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{inputs.file_type}}
 

--- a/.github/workflows/verify-and-create-draft-release.yml
+++ b/.github/workflows/verify-and-create-draft-release.yml
@@ -16,7 +16,7 @@ jobs:
   generate_tarballs:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       id: checkout
      
     - name: Generate tarballs 
@@ -27,12 +27,12 @@ jobs:
         bash ./.github/scripts/build.sh
 
       shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: zip
         path: |
           /tmp/build/${{ github.event.inputs.engine_tag }}.zip
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: tar
         path: |
@@ -58,13 +58,13 @@ jobs:
       GH_TOKEN: ${{ secrets.RELEASE_PRIVATE_KEY }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: zip
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tar
 


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Task: No-Jira

Signed-off-by: Shard Gupta <shardga@amazon.com>